### PR TITLE
fix: add required error definition

### DIFF
--- a/migrate/error.go
+++ b/migrate/error.go
@@ -8,4 +8,5 @@ var (
 	ErrMigrationCanceled   = errors.New("rollback migration canceled")
 	ErrEmptyPurpose        = errors.New("missing purpose when creating migration")
 	ErrDuplicatedMigration = errors.New("migration exists")
+	ErrNoMigration         = errors.New("running with no migration")
 )


### PR DESCRIPTION
Like title mentioned, there is a missing defined error for running with no migration.